### PR TITLE
Fix Mermaid code extraction regex

### DIFF
--- a/script.js
+++ b/script.js
@@ -78,7 +78,7 @@ Do not include any other text, explanations, or titles before or after the code 
     // --- Mermaid Code Extraction Function ---
     function extractMermaidCode(responseText) {
         if (!responseText) return null;
-        const match = responseText.match(/```mermaid\n([\s\S]*?)\n```/);
+        const match = responseText.match(/```mermaid\r?\n([\s\S]*?)\r?\n```/);
         return match ? match[1].trim() : null;
     }
     


### PR DESCRIPTION
## Summary
- fix extraction regex to correctly detect Mermaid code blocks with optional CRLF line endings

## Testing
- `node - <<'NODE'
function extractMermaidCode(responseText) {
    if (!responseText) return null;
    const match = responseText.match(/```mermaid\r?\n([\s\S]*?)\r?\n```/);
    return match ? match[1].trim() : null;
}
const text = "Here it is:\n```mermaid\ngraph TD; A-->B;\n```\n";
console.log('Extracted:', extractMermaidCode(text));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6897a3434ad88322b454efce65652977