### PR TITLE
feat: add code view tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Session-based API key input (no backend required)
 
 Works with Gemini via Google AI Studio
 
+Tabbed viewer to switch between rendered diagram and Mermaid source
+
 "Copy Mermaid Code" button for manual export
 
 Export guidance for importing into draw.io or other tools

--- a/index.html
+++ b/index.html
@@ -17,9 +17,16 @@
             <p>Turn text prompts into diagrams with AI.</p>
         </header>
 
-        <!-- The area where the Mermaid diagram will be rendered -->
-        <div id="diagram-container" class="diagram-container">
-            <p class="placeholder-text">Your generated diagram will appear here...</p>
+        <!-- The area where the Mermaid diagram and code will be displayed -->
+        <div class="viewer-container">
+            <div class="tabs">
+                <button id="diagram-tab" class="tab active">Diagram</button>
+                <button id="code-tab" class="tab">Code</button>
+            </div>
+            <div id="diagram-container" class="diagram-container">
+                <p class="placeholder-text">Your generated diagram will appear here...</p>
+            </div>
+            <pre id="code-container" class="code-container hidden"><code id="code-block" class="placeholder-text">Mermaid code will appear here...</code></pre>
         </div>
 
         <!-- The input controls -->

--- a/script.js
+++ b/script.js
@@ -5,9 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const promptInput = document.getElementById('prompt-input');
     const generateBtn = document.getElementById('generate-btn');
     const diagramContainer = document.getElementById('diagram-container');
+    const diagramTab = document.getElementById('diagram-tab');
+    const codeTab = document.getElementById('code-tab');
+    const codeContainer = document.getElementById('code-container');
+    const codeBlock = document.getElementById('code-block');
 
-    // --- Event Listener ---
+    // --- Event Listeners ---
     generateBtn.addEventListener('click', handleGenerateClick);
+    diagramTab.addEventListener('click', () => switchTab('diagram'));
+    codeTab.addEventListener('click', () => switchTab('code'));
 
     // --- Main Function to Handle Generation ---
     async function handleGenerateClick() {
@@ -24,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         setLoadingState(true);
+        switchTab('diagram');
         diagramContainer.innerHTML = '<p class="placeholder-text">Generating diagram, please wait...</p>';
 
         try {
@@ -88,7 +95,10 @@ Do not include any other text, explanations, or titles before or after the code 
             diagramContainer.innerHTML = `<p class="placeholder-text" style="color: var(--error-color);">Could not extract valid Mermaid code from the API response. The response may have been empty or in an unexpected format.</p>`;
             return;
         }
-        
+
+        codeBlock.textContent = mermaidCode;
+        codeBlock.classList.remove('placeholder-text');
+
         try {
             // Unique ID for Mermaid to render into
             const renderId = 'mermaid-graph-' + Date.now();
@@ -109,6 +119,20 @@ Do not include any other text, explanations, or titles before or after the code 
         } else {
             generateBtn.classList.remove('loading');
             generateBtn.textContent = 'Generate Diagram';
+        }
+    }
+
+    function switchTab(view) {
+        if (view === 'diagram') {
+            diagramTab.classList.add('active');
+            codeTab.classList.remove('active');
+            diagramContainer.classList.remove('hidden');
+            codeContainer.classList.add('hidden');
+        } else {
+            diagramTab.classList.remove('active');
+            codeTab.classList.add('active');
+            diagramContainer.classList.add('hidden');
+            codeContainer.classList.remove('hidden');
         }
     }
 });

--- a/style.css
+++ b/style.css
@@ -115,3 +115,46 @@ button.loading {
     cursor: not-allowed;
     background-color: #a9cce3;
 }
+
+/* --- Viewer Tabs and Code Container --- */
+.tabs {
+    display: flex;
+}
+
+.tab {
+    flex: 1;
+    padding: 10px;
+    background-color: var(--container-bg);
+    border: 1px solid var(--border-color);
+    cursor: pointer;
+    text-align: center;
+}
+
+.tab:not(:last-child) {
+    border-right: none;
+}
+
+.tab.active {
+    background-color: var(--primary-color);
+    color: white;
+}
+
+.code-container {
+    background-color: var(--container-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    min-height: 400px;
+    padding: 20px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    overflow: auto;
+    font-family: monospace;
+}
+
+.code-container code {
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.hidden {
+    display: none;
+}


### PR DESCRIPTION
## Summary
- add tabbed viewer to toggle between diagram and mermaid code
- wire up tab switching logic and populate code block after generation
- style tab controls and code panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68989c10fd808322aef844c7a7e3efb4