### PR TITLE
Improve layout, tab clarity, and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,18 +17,6 @@
             <p>Turn text prompts into diagrams with AI.</p>
         </header>
 
-        <!-- The area where the Mermaid diagram and code will be displayed -->
-        <div class="viewer-container">
-            <div class="tabs">
-                <button id="diagram-tab" class="tab active">Diagram</button>
-                <button id="code-tab" class="tab">Code</button>
-            </div>
-            <div id="diagram-container" class="diagram-container">
-                <p class="placeholder-text">Your generated diagram will appear here...</p>
-            </div>
-            <pre id="code-container" class="code-container hidden"><code id="code-block" class="placeholder-text">Mermaid code will appear here...</code></pre>
-        </div>
-
         <!-- The input controls -->
         <div class="controls-container">
             <div class="api-key-container">
@@ -37,6 +25,18 @@
             </div>
             <textarea id="prompt-input" placeholder="e.g., A flowchart for a user login process with success and failure paths..."></textarea>
             <button id="generate-btn">Generate Diagram</button>
+        </div>
+
+        <!-- The area where the Mermaid diagram and code will be displayed -->
+        <div class="viewer-container">
+            <div class="tabs" role="tablist">
+                <button id="diagram-tab" class="tab active" role="tab" aria-selected="true">Diagram</button>
+                <button id="code-tab" class="tab" role="tab" aria-selected="false">Code</button>
+            </div>
+            <div id="diagram-container" class="diagram-container">
+                <p class="placeholder-text">Your generated diagram will appear here...</p>
+            </div>
+            <pre id="code-container" class="code-container hidden"><code id="code-block" class="placeholder-text">Mermaid code will appear here...</code></pre>
         </div>
 
     </div>

--- a/script.js
+++ b/script.js
@@ -122,17 +122,21 @@ Do not include any other text, explanations, or titles before or after the code 
         }
     }
 
-    function switchTab(view) {
-        if (view === 'diagram') {
-            diagramTab.classList.add('active');
-            codeTab.classList.remove('active');
-            diagramContainer.classList.remove('hidden');
-            codeContainer.classList.add('hidden');
-        } else {
-            diagramTab.classList.remove('active');
-            codeTab.classList.add('active');
-            diagramContainer.classList.add('hidden');
-            codeContainer.classList.remove('hidden');
-        }
-    }
-});
+      function switchTab(view) {
+          if (view === 'diagram') {
+              diagramTab.classList.add('active');
+              codeTab.classList.remove('active');
+              diagramContainer.classList.remove('hidden');
+              codeContainer.classList.add('hidden');
+              diagramTab.setAttribute('aria-selected', 'true');
+              codeTab.setAttribute('aria-selected', 'false');
+          } else {
+              diagramTab.classList.remove('active');
+              codeTab.classList.add('active');
+              diagramContainer.classList.add('hidden');
+              codeContainer.classList.remove('hidden');
+              diagramTab.setAttribute('aria-selected', 'false');
+              codeTab.setAttribute('aria-selected', 'true');
+          }
+      }
+  });

--- a/style.css
+++ b/style.css
@@ -46,7 +46,8 @@ body {
 .diagram-container {
     background-color: var(--container-bg);
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-top: none;
+    border-radius: 0 0 8px 8px;
     min-height: 400px;
     padding: 20px;
     box-shadow: 0 4px 6px rgba(0,0,0,0.05);
@@ -104,6 +105,9 @@ button {
     font-weight: 500;
     cursor: pointer;
     transition: background-color 0.2s;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
 
 button:hover {
@@ -116,22 +120,39 @@ button.loading {
     background-color: #a9cce3;
 }
 
+button.loading::after {
+    content: "";
+    margin-left: 8px;
+    border: 2px solid white;
+    border-top-color: transparent;
+    border-radius: 50%;
+    width: 16px;
+    height: 16px;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
+}
+
 /* --- Viewer Tabs and Code Container --- */
 .tabs {
     display: flex;
+    border: 1px solid var(--border-color);
+    border-bottom: none;
+    border-radius: 8px 8px 0 0;
+    overflow: hidden;
 }
 
 .tab {
     flex: 1;
     padding: 10px;
-    background-color: var(--container-bg);
-    border: 1px solid var(--border-color);
+    background-color: #f0f0f0;
+    color: var(--text-color);
     cursor: pointer;
     text-align: center;
-}
-
-.tab:not(:last-child) {
-    border-right: none;
+    transition: background-color 0.2s;
 }
 
 .tab.active {
@@ -139,10 +160,15 @@ button.loading {
     color: white;
 }
 
+.tab:not(.active):hover {
+    background-color: #e0e0e0;
+}
+
 .code-container {
     background-color: var(--container-bg);
     border: 1px solid var(--border-color);
-    border-radius: 8px;
+    border-top: none;
+    border-radius: 0 0 8px 8px;
     min-height: 400px;
     padding: 20px;
     box-shadow: 0 4px 6px rgba(0,0,0,0.05);
@@ -157,4 +183,18 @@ button.loading {
 
 .hidden {
     display: none;
+}
+
+/* Responsive tweaks */
+@media (max-width: 600px) {
+    .diagram-container,
+    .code-container {
+        min-height: 250px;
+        padding: 10px;
+    }
+
+    button {
+        padding: 12px;
+        font-size: 1em;
+    }
 }


### PR DESCRIPTION
## Summary
- Move API key and prompt controls above diagram viewer so inputs are visible on load
- Style viewer tabs for better contrast and accessibility; add loading spinner to generate button
- Add responsive CSS tweaks for small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898c38d58dc832283f84c77b3acde0d